### PR TITLE
use a constant time for prebundle zip entries

### DIFF
--- a/src/main/kotlin/gg/essential/gradle/util/prebundle.kt
+++ b/src/main/kotlin/gg/essential/gradle/util/prebundle.kt
@@ -48,7 +48,7 @@ private fun Project.bundle(configuration: Configuration, filter: PatternSet, jij
     val hash = configuration.computeHash().apply {
         update(filter.hashCode().toBigInteger().toByteArray())
         update(jijName?.toByteArray() ?: byteArrayOf())
-        update(byteArrayOf(0, 0, 0, 1)) // code version, incremented with each semantic change
+        update(byteArrayOf(0, 0, 0, 2)) // code version, incremented with each semantic change
     }.digest()
     val hashFile = output.resolveSibling(output.name + ".md5")
     if (hashFile.exists() && hashFile.readBytes().contentEquals(hash) && output.exists()) {
@@ -75,7 +75,7 @@ private fun Project.bundle(configuration: Configuration, filter: PatternSet, jij
                     if (!visitedEntries.add(path)) return@visit
                     if (!spec.isSatisfiedBy(this)) return@visit
 
-                    jarOut.putNextEntry(ZipEntry(if (isDirectory) "$path/" else path))
+                    jarOut.putNextEntry(ZipEntry(if (isDirectory) "$path/" else path).apply { time = CONSTANT_TIME_FOR_ZIP_ENTRIES })
                     open().use { copyTo(jarOut) }
                     jarOut.closeEntry()
                 }

--- a/src/main/kotlin/gg/essential/gradle/util/utils.kt
+++ b/src/main/kotlin/gg/essential/gradle/util/utils.kt
@@ -2,6 +2,8 @@ package gg.essential.gradle.util
 
 import org.gradle.api.GradleException
 import org.gradle.api.JavaVersion
+import java.util.Calendar
+import java.util.GregorianCalendar
 
 internal fun checkJavaVersion(minVersion: JavaVersion) {
     if (JavaVersion.current() < minVersion) {
@@ -23,3 +25,7 @@ internal fun compatibleKotlinMetadataVersion(version: IntArray): IntArray {
     }
     return version
 }
+
+// A safe, constant value for creating consistent zip entries
+// From: https://github.com/gradle/gradle/blob/d6c7fd470449a59fc57a26b4ebc0ad83c64af50a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java#L42-L57
+val CONSTANT_TIME_FOR_ZIP_ENTRIES = GregorianCalendar(1980, Calendar.FEBRUARY, 1, 0, 0, 0).timeInMillis


### PR DESCRIPTION
this allows for more deterministic builds when using prebundle