### PR TITLE
Misc: Update loom to 1.2.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .gradle/
 build/
+.idea/

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-archloom = "1.2.2"
+archloom = "1.2.8"
 archloomPack200 = "0.1.3"
 kotlin = "1.8.21"
 kotlinx-binaryCompatibilityValidator = "0.13.1"


### PR DESCRIPTION
Needed in Elementa to import as it fixes an error that is thrown when importing the project into IntelliJ.