### PR TITLE
Platform: Support Minecraft 1.20.5

### DIFF
--- a/src/main/kotlin/gg/essential/gradle/multiversion/Platform.kt
+++ b/src/main/kotlin/gg/essential/gradle/multiversion/Platform.kt
@@ -20,6 +20,7 @@ data class Platform(
     val isLegacyForge = loader == Loader.Forge && mcVersion < 11400
 
     val javaVersion = when {
+        mcVersion >= 12005 -> JavaVersion.VERSION_21
         mcVersion >= 11800 -> JavaVersion.VERSION_17
         mcVersion >= 11700 -> JavaVersion.VERSION_16
         else -> JavaVersion.VERSION_1_8


### PR DESCRIPTION
Kotlin 1.9 support needs to be merged to preprocessor and preprocessor should be bumped in EGT before this is merged.