### PR TITLE
Add Fabric support for Minecraft 1.21.9, 1.21.10, and 1.21.11

### DIFF
--- a/src/main/kotlin/gg/essential/defaults/loom.gradle.kts
+++ b/src/main/kotlin/gg/essential/defaults/loom.gradle.kts
@@ -37,6 +37,9 @@ val revisions = mutableListOf<Revision>()
 // one until they opt-in to the new one.
 revisions.add(Revision(
     yarn = mapOf(
+        12111 to "1.21.11+build.4:v2",
+        12110 to "1.21.10+build.3:v2",
+        12109 to "1.21.9+build.1:v2",
         12108 to "1.21.8+build.1:v2",
         12107 to "1.21.7+build.6:v2",
         12106 to "1.21.6+build.1:v2",


### PR DESCRIPTION
This pull request adds support for three new Minecraft Yarn revisions in the build configuration.

Dependency updates:

* Added entries for versions `1.21.11+build.4:v2`, `1.21.10+build.3:v2`, and `1.21.9+build.1:v2` to the `yarn` mapping in the `revisions` list in `loom.gradle.kts`.